### PR TITLE
Configuración del idioma del instalador MSI

### DIFF
--- a/src/main/java/io/github/fvarrui/javapackager/model/WindowsConfig.java
+++ b/src/main/java/io/github/fvarrui/javapackager/model/WindowsConfig.java
@@ -52,6 +52,7 @@ public class WindowsConfig implements Serializable {
 	private WindowsExeCreationTool exeCreationTool = WindowsExeCreationTool.launch4j;
 	private String vmLocation;
 	private WixUi wixUi;
+	private String culture;
 
 	public File getIcoFile() {
 		return icoFile;
@@ -325,6 +326,14 @@ public class WindowsConfig implements Serializable {
 		this.wixUi = wixUi;
 	}
 
+	public String getCulture() {
+		return culture;
+	}
+
+	public void setCulture(String culture) {
+		this.culture = culture;
+	}
+
 	@Override
 	public String toString() {
 		return "WindowsConfig [icoFile=" + icoFile + ", headerType=" + headerType + ", companyName=" + companyName
@@ -339,7 +348,7 @@ public class WindowsConfig implements Serializable {
 				+ ", generateSetup=" + generateSetup + ", generateMsi=" + generateMsi + ", generateMsm=" + generateMsm
 				+ ", msiUpgradeCode=" + msiUpgradeCode + ", wrapJar=" + wrapJar + ", setupLanguages=" + setupLanguages
 				+ ", setupMode=" + setupMode + ", signing=" + signing + ", registry=" + registry + ", removeOldLibs="
-				+ removeOldLibs + ", exeCreationTool=" + exeCreationTool + ", vmLocation=" + vmLocation + "]";
+				+ removeOldLibs + ", exeCreationTool=" + exeCreationTool + ", vmLocation=" + vmLocation + ", wixUi=" + wixUi + ", culture=" + culture + "]";
 	}
 
 	/**

--- a/src/main/java/io/github/fvarrui/javapackager/model/WindowsConfig.java
+++ b/src/main/java/io/github/fvarrui/javapackager/model/WindowsConfig.java
@@ -52,7 +52,7 @@ public class WindowsConfig implements Serializable {
 	private WindowsExeCreationTool exeCreationTool = WindowsExeCreationTool.launch4j;
 	private String vmLocation;
 	private WixUi wixUi;
-	private String culture;
+	private String culture = "";
 
 	public File getIcoFile() {
 		return icoFile;

--- a/src/main/java/io/github/fvarrui/javapackager/packagers/GenerateMsi.java
+++ b/src/main/java/io/github/fvarrui/javapackager/packagers/GenerateMsi.java
@@ -73,10 +73,10 @@ public class GenerateMsi extends ArtifactGenerator<WindowsPackager> {
 		if(wixImages.exists()){
 			Logger.info("WIX IMAGES EXISTS FOR MSI");
 			List<String> lightArguments = getLightArguments(wixImages);
-			CommandUtils.execute("light", "-sw1076", "-spdb",lightArguments.get(0),lightArguments.get(1),lightArguments.get(2),lightArguments.get(3),lightArguments.get(4),lightArguments.get(5),lightArguments.get(6),lightArguments.get(7), "-out", msiFile, wixobjFile);
+			CommandUtils.execute("light", packager.getWinConfig().getCulture(),"-sw1076", "-spdb",lightArguments.get(0),lightArguments.get(1),lightArguments.get(2),lightArguments.get(3),lightArguments.get(4),lightArguments.get(5),lightArguments.get(6),lightArguments.get(7), "-out", msiFile, wixobjFile);
 		}
 		else{
-			CommandUtils.execute("light", "-sw1076", "-spdb", "-out", msiFile, wixobjFile);
+			CommandUtils.execute("light", packager.getWinConfig().getCulture(),"-sw1076", "-spdb", "-out", msiFile, wixobjFile);
 		}
 
 		// setup file


### PR DESCRIPTION
Actualmente el wizard de instalación MSI estaba a fuego en inglés. Con este cambio mediante configuración añadimos el comando -culture para localizar el instalador al idioma elegido. En caso de no configurarse seguirá por defecto en inglés.

https://docs.firegiant.com/wix3/howtos/ui_and_localization/specifying_cultures_to_build/