### PR TITLE
Normalize entity.values for exe and msi

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
 }
 
 group = 'io.github.fvarrui'
-version = '1.7.7-SNAPSHOT'
+version = '1.7.8-SNAPSHOT'
 description = 'Hybrid Maven/Gradle plugin to package Java applications as native Windows, Mac OS X or GNU/Linux executables and create installers for them'
 
 sourceCompatibility = JavaVersion.VERSION_1_8

--- a/src/main/java/io/github/fvarrui/javapackager/packagers/GenerateSetup.java
+++ b/src/main/java/io/github/fvarrui/javapackager/packagers/GenerateSetup.java
@@ -7,6 +7,7 @@ import io.github.fvarrui.javapackager.utils.CommandUtils;
 import io.github.fvarrui.javapackager.utils.FileUtils;
 import io.github.fvarrui.javapackager.utils.Logger;
 import io.github.fvarrui.javapackager.utils.VelocityUtils;
+import io.github.fvarrui.javapackager.utils.XMLUtils;
 import net.jsign.WindowsSigner;
 
 /**
@@ -49,6 +50,9 @@ public class GenerateSetup extends ArtifactGenerator<WindowsPackager> {
 		// generates iss file from velocity template
 		File issFile = new File(assetsFolder, name + ".iss");
 		VelocityUtils.render("windows/iss.vtl", issFile, packager);
+
+		//pretify iss file
+		XMLUtils.replaceWordInXMLFile(issFile,"quotes","\"\"" );
 
 		// generates Windows installer with inno setup command line compiler
 		CommandUtils.execute("iscc", "/O" + outputDirectory.getAbsolutePath(), "/F" + name + "_" + version, issFile);

--- a/src/main/resources/windows/iss.vtl
+++ b/src/main/resources/windows/iss.vtl
@@ -68,7 +68,13 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 [Registry]
 #if ($info.winConfig.registry)
 #foreach ($entry in $info.winConfig.registry.entries)
+#if ($entry.values)
+#foreach ($registryValue in $entry.values)
+Root: ${entry.root}; Subkey: "${entry.subkey}"; ValueType: ${registryValue.valueTypeAsInnoSetupString}; ValueName: "$!{registryValue.valueName}"; #if ($registryValue.valueData) ValueData: "${registryValue.valueData}"; #else ValueData: ""; #end Flags: uninsdeletevalue
+#end
+#else
 Root: ${entry.root}; Subkey: "${entry.subkey}"; ValueType: ${entry.valueTypeAsInnoSetupString}; ValueName: "$!{entry.valueName}"; ValueData: "$!{entry.valueData}"; Flags: uninsdeletevalue
+#end
 #end
 #end
 #foreach ($fileAssociation in $info.fileAssociations)


### PR DESCRIPTION
Fix iss.vlt for values pom format . Its needed por setup installer (.exe)



<!-- ALLOW THIS -->

                                    <valueName>exampleName</valueName>
                                    <valueType>REG_SZ</valueType>
                                    <valueData>exampleData</valueData>

                                    <!-- AND  THIS -->

                                    <values>
                                        <value>
                                            <valueName>name1</valueName>
                                            <valueType>REG_SZ</valueType>
                                            <valueData>data1</valueData>
                                        </value>
                                        <value>
                                            <valueName>name2</valueName>
                                            <valueType>REG_SZ</valueType>
                                            <valueData>data2</valueData>
                                        </value>
                                        <value>
                                            <valueName>name3</valueName>
                                            <valueType>REG_SZ</valueType>
                                            <valueData>data3</valueData>
                                        </value>
                                    </values>


                                </entry>
                            </entries>
                        </registry>